### PR TITLE
[Main]LoraをRTCのスリープで叩き起こすプログラム

### DIFF
--- a/RTC_Lora_sleep1/RTC_Lora_Receive/RTC_Lora_Receive.ino
+++ b/RTC_Lora_sleep1/RTC_Lora_Receive/RTC_Lora_Receive.ino
@@ -57,41 +57,41 @@ void setRtcConfig(){
 void setLoraInit() {
     Serial.println("Start...");
     // コマンドモード開始
-    loraConfigSend("2"); 
+    setLoraConfig("2"); 
     //nodeの種別設定
-    loraConfigSend("node 2");
+    setLoraConfig("node 2");
     // bw（帯域幅の設定）
-    loraConfigSend("bw 5"); 
+    setLoraConfig("bw 5"); 
     // sf（拡散率の設定）
-    loraConfigSend("sf 12"); 
+    setLoraConfig("sf 12"); 
     //channel設定
-    loraConfigSend("channel 1"); 
+    setLoraConfig("channel 1"); 
     // 自分が参加するPANネットワークアドレスの設定
-    loraConfigSend("panid 0002"); 
+    setLoraConfig("panid 0002"); 
     // 自分のノードIDを設定
-    loraConfigSend("ownid 0012"); 
+    setLoraConfig("ownid 1012"); 
     //送信元ノードネットワークアドレス
-    loraConfigSend("dstid 1012"); 
+    setLoraConfig("dstid ffff"); 
     // ack受信の設定
-    loraConfigSend("ack 2"); 
+    setLoraConfig("ack 2"); 
     // 転送モード設定
-    loraConfigSend("n 1"); 
+    setLoraConfig("n 1"); 
     // RRSIの付与設定
-    loraConfigSend("p 1"); 
+    setLoraConfig("p 1"); 
     // sleepの設定
-    loraConfigSend("s 3"); 
+    setLoraConfig("s 3"); 
     // UART転送速度設定
-    loraConfigSend("r 1"); 
+    setLoraConfig("r 1"); 
     // 設定を保存する
-    loraConfigSend("w");
+    setLoraConfig("w");
     // 通信の開始
-    loraConfigSend("z");
+    setLoraConfig("z");
     // 送信データの内容
     Serial.println("Set up OK!");
 }
 
 /* loraにConfigを送る関数 */
-void loraConfigSend(String Config){
+void setLoraConfig(String Config){
     LoraSerial.println(Config);
     clearBuffer();
 }

--- a/RTC_Lora_sleep1/RTC_Lora_Receive/RTC_Lora_Receive.ino
+++ b/RTC_Lora_sleep1/RTC_Lora_Receive/RTC_Lora_Receive.ino
@@ -15,6 +15,7 @@
 #define BAUTRATE 9600   /*BautRate*/
 #define READTIME 1000   /*読み込み時間*/
 
+SoftwareSerial LoraSerial(LORA_RX, LORA_TX);
 
 void interrput()
 {

--- a/RTC_Lora_sleep1/RTC_Lora_Receive/RTC_Lora_Receive.ino
+++ b/RTC_Lora_sleep1/RTC_Lora_Receive/RTC_Lora_Receive.ino
@@ -18,14 +18,6 @@
 
 SoftwareSerial LoraSerial(LORA_RX, LORA_TX);
 
-/* Sleepを解除する割り込み関数 */
-void interrput()
-{
-    Serial.println("interrupt_message");
-    Serial.println("light up LED 5s");
-    Serial.println("-----------------");
-}
-
 /* RTCの設定を初期化する関数 */
 void setRtcConfig(){
     Wire.begin(); // arudinoをマスターとして接続
@@ -61,18 +53,6 @@ void setRtcConfig(){
     Wire.endTransmission();
 }
 
-/* Loraを再起動させる関数 */
-void restartLora(){
-    pinMode(RST_PIN, OUTPUT);
-    digitalWrite(RST_PIN, LOW);
-    delay(BOOTDELAY);
-    digitalWrite(RST_PIN, HIGH); 
-    delay(BOOTDELAY);
-
-    Serial.begin(BAUTRATE);
-    LoraSerial.begin(BAUTRATE);
-}
-
 /* loraの初期化関数 */
 void loraInit() {
     Serial.println("Start...");
@@ -89,27 +69,24 @@ void loraInit() {
     // 自分が参加するPANネットワークアドレスの設定
     loraConfigSend("panid 0002"); 
     // 自分のノードIDを設定
-    loraConfigSend("ownid 1012"); 
+    loraConfigSend("ownid 0012"); 
     //送信元ノードネットワークアドレス
-    loraConfigSend("dstid ffff"); 
+    loraConfigSend("dstid 1012"); 
     // ack受信の設定
     loraConfigSend("ack 2"); 
     // 転送モード設定
     loraConfigSend("n 1"); 
     // RRSIの付与設定
     loraConfigSend("p 1"); 
-    // UART転送速度設定
-    loraConfigSend("r 1"); 
     // sleepの設定
     loraConfigSend("s 3"); 
-    // 自動送信間隔
-    loraConfigSend("B 0"); 
-    // 自動送信データ設定
-    loraConfigSend("C receiveSide"); 
+    // UART転送速度設定
+    loraConfigSend("r 1"); 
     // 設定を保存する
     loraConfigSend("w");
     // 通信の開始
     loraConfigSend("z");
+    // 送信データの内容
     Serial.println("Set up OK!");
 }
 
@@ -125,6 +102,32 @@ void clearBuffer() {
     while (LoraSerial.available() > 0) LoraSerial.read();
 }
 
+/* Loraを再起動させる関数 */
+void restartLora(){
+    pinMode(RST_PIN, OUTPUT);
+    digitalWrite(RST_PIN, LOW);
+    delay(BOOTDELAY);
+    digitalWrite(RST_PIN, HIGH); 
+    delay(BOOTDELAY);
+
+    Serial.begin(BAUTRATE);
+    LoraSerial.begin(BAUTRATE);
+}
+
+/* Arduino,Loraをスリープさせる関数 */
+void setSystemSleep(){
+    digitalWrite(SLEEP_PIN, HIGH);          //Lora sleep_mode
+    set_sleep_mode(SLEEP_MODE_PWR_DOWN);    //スリープモード設定
+}
+
+/* Sleepを解除する割り込み関数 */
+void interrput()
+{
+    Serial.println("interrupt_message");
+    Serial.println("light up LED 5s");
+}
+
+/* Dataを読み出す関数*/
 void loraDataRead(){
     String Data;
     if(LoraSerial.read() == -1){
@@ -135,12 +138,6 @@ void loraDataRead(){
         Serial.println(Data.substring(11)); //データ部分だけ表示
     }
     delay(READTIME);
-}
-
-/* Arduino,Loraをスリープさせる関数 */
-void setSystemSleep(){
-    digitalWrite(SLEEP_PIN, HIGH);          //Lora sleep_mode
-    set_sleep_mode(SLEEP_MODE_PWR_DOWN);    //スリープモード設定
 }
 
 /* Main関数 */

--- a/RTC_Lora_sleep1/RTC_Lora_Receive/RTC_Lora_Receive.ino
+++ b/RTC_Lora_sleep1/RTC_Lora_Receive/RTC_Lora_Receive.ino
@@ -54,7 +54,7 @@ void setRtcConfig(){
 }
 
 /* loraの初期化関数 */
-void loraInit() {
+void setLoraInit() {
     Serial.println("Start...");
     // コマンドモード開始
     loraConfigSend("2"); 
@@ -103,7 +103,7 @@ void clearBuffer() {
 }
 
 /* Loraを再起動させる関数 */
-void restartLora(){
+void setRestartLora(){
     pinMode(RST_PIN, OUTPUT);
     digitalWrite(RST_PIN, LOW);
     delay(BOOTDELAY);
@@ -128,7 +128,7 @@ void interrput()
 }
 
 /* Dataを読み出す関数*/
-void loraDataRead(){
+void readLoraData(){
     String Data;
     if(LoraSerial.read() == -1){
         Serial.println("Nothing Data");
@@ -155,8 +155,8 @@ void setup()
     Serial.print("start!!\n---------------------------\n");
 
     setSystemSleep();
-    restartLora();
-    loraInit();
+    setRestartLora();
+    setLoraInit();
     setRtcConfig();
 }
 
@@ -172,7 +172,7 @@ void loop()
     while (n < 5)
     {
         Serial.println("-----------------");
-        loraDataRead();
+        readLoraData();
         n++;
     }
 

--- a/RTC_Lora_sleep1/RTC_Lora_Receive/RTC_Lora_Receive.ino
+++ b/RTC_Lora_sleep1/RTC_Lora_Receive/RTC_Lora_Receive.ino
@@ -22,6 +22,7 @@ void interrput()
 {
     Serial.println("interrupt_message");
     Serial.println("light up LED 5s");
+    Serial.println("-----------------");
 }
 
 void setRtcConfig(){
@@ -138,8 +139,8 @@ void setSystemSleep(){
 
 void setup()
 {
-    pinMode(Lora_SLEEP_PIN,OUTPUT);         //Loraのスリープピン初期化
-    digitalWrite(Lora_SLEEP_PIN, LOW);      //Low = active_mode　High = sleep_mode
+    pinMode(SLEEP_PIN,OUTPUT);         //Loraのスリープピン初期化
+    digitalWrite(SLEEP_PIN, LOW);      //Low = active_mode　High = sleep_mode
 
     pinMode(LED, OUTPUT);                   //13を出力設定(LED用)
     pinMode(INPIN, INPUT_PULLUP);           //2番をプルアップ設定
@@ -172,6 +173,7 @@ void loop()
     }
 
     n = 0;
+    Serial.println("Good night!");
     setSystemSleep();    
     digitalWrite(LED, 0);
 }

--- a/RTC_Lora_sleep1/RTC_Lora_Receive/RTC_Lora_Receive.ino
+++ b/RTC_Lora_sleep1/RTC_Lora_Receive/RTC_Lora_Receive.ino
@@ -9,8 +9,8 @@
 
 #define SLEEP_PIN 12    /*スリープピン*/
 #define RST_PIN 13      /*リセットピン*/
-#define LORA_RX 4       /*Software_RX_2*/
-#define LORA_TX 5       /*Software_TX_3*/
+#define LORA_RX 4       /*Software_RX_4*/
+#define LORA_TX 5       /*Software_TX_5*/
 #define CMDDELAY 100    /*CMD待機時間*/
 #define BOOTDELAY 1500  /*Boot待機時間*/
 #define BAUTRATE 9600   /*BautRate*/

--- a/RTC_Lora_sleep1/RTC_Lora_Receive/RTC_Lora_Receive.ino
+++ b/RTC_Lora_sleep1/RTC_Lora_Receive/RTC_Lora_Receive.ino
@@ -162,7 +162,7 @@ void loop()
     sleep_cpu();        //スリープ開始(ここでプログラムは停止する)
     sleep_disable();    //スリープを無効化
     digitalWrite(LED, 1);
-    digitalWrite(ES920LR_RST_PIN, LOW); //Lora Acctive_mode
+    digitalWrite(SLEEP_PIN, LOW);        //Lora Acctive_mode
     digitalWrite(LED, 1);
     while (n < 5)
     {

--- a/RTC_Lora_sleep1/RTC_Lora_Receive/RTC_Lora_Receive.ino
+++ b/RTC_Lora_sleep1/RTC_Lora_Receive/RTC_Lora_Receive.ino
@@ -1,0 +1,165 @@
+#include <Wire.h>
+#include <avr/sleep.h>
+#include <SoftwareSerial.h>
+
+#define inPin 2
+#define LED 10
+#define RTCaddress 0xa2 >> 1
+//RTC8564のスレーブアドレスは『0xA2』固定だが、Wireライブラリでは7ビットでデバイス特定をするため、右に1ビットシフトさせて指定
+
+#define RST_PIN 13      /*リセットピン*/
+#define LORA_RX 4       /*Software_RX_2*/
+#define LORA_TX 5       /*Software_TX_3*/
+#define CMDDELAY 100    /*CMD待機時間*/
+#define BOOTDELAY 1500  /*Boot待機時間*/
+#define BAUTRATE 9600   /*BautRate*/
+#define READTIME 1000   /*読み込み時間*/
+
+
+void interrput()
+{
+    Serial.println("interrupt_message");
+    Serial.println("light up LED 5s");
+}
+
+void setRtcConfig(){
+    Wire.begin(); // arudinoをマスターとして接続
+    delay(1000);  // 発振子の動作待機
+
+    Wire.beginTransmission(RTCaddress); //接続するIC2のモジュールを選択
+    Wire.write(0x00);                   // データを転送するレジスタ番号を指定
+    Wire.write(0b00100000);                   // 00 Control 1　STOP = 1 動作停止
+    Wire.write(0x00);                         // 01 Control 2 
+    Wire.write(0b00000001);                   // 02 Seconds　
+    Wire.write(0b00000000);                   // 03 Minutes
+    Wire.write(0b00000000);                   // 04 Hours
+    Wire.write(0b00000001);                   // 05 Days
+    Wire.write(0b00000001);                   // 06 Weekdays
+    Wire.write(0b00000001);                   // 07 Months
+    Wire.write(0b00100000);                   // 08 Years
+    //20年1月１日00:00に設定
+
+    //Alram レジスタ
+    Wire.write(0x00);       // 09 Minutes Alarm　
+    Wire.write(0x00);       // 0A Hours Alarm
+    Wire.write(0x00);       // 0B Days Alarm
+    Wire.write(0x00);       // 0C Weekdays Alarm
+
+    //timerレジスタ
+    Wire.write(0x00);       // 0D CLKOUT
+    Wire.write(0b10000010); // 0E TimerControl
+    Wire.write(0b00001111); // 0F Timer 15秒設定
+
+    // Control 設定
+    Wire.write(0x00);       // 00 Control 1　STOP = 0 動作開始
+    Wire.write(0b00010001); //Control 2 Ti/Tp = 1 TIE = 1
+    Wire.endTransmission();
+}
+
+// LoRaを再起動させる関数
+void restartLora(){
+    pinMode(RST_PIN, OUTPUT);
+    digitalWrite(RST_PIN, LOW);
+    delay(BOOTDELAY);
+    digitalWrite(RST_PIN, HIGH); 
+    delay(BOOTDELAY);
+
+    Serial.begin(BAUTRATE);
+    LoraSerial.begin(BAUTRATE);
+}
+
+void loraInit() {
+    Serial.println("Start...");
+    // コマンドモード開始
+    loraConfigSend("2"); 
+    //nodeの種別設定
+    loraConfigSend("node 2");
+    // bw（帯域幅の設定）
+    loraConfigSend("bw 5"); 
+    // sf（拡散率の設定）
+    loraConfigSend("sf 12"); 
+    //channel設定
+    loraConfigSend("channel 1"); 
+    // 自分が参加するPANネットワークアドレスの設定
+    loraConfigSend("panid 0002"); 
+    // 自分のノードIDを設定
+    loraConfigSend("ownid 1012"); 
+    //送信元ノードネットワークアドレス
+    loraConfigSend("dstid ffff"); 
+    // ack受信の設定
+    loraConfigSend("ack 2"); 
+    // 転送モード設定
+    loraConfigSend("n 1"); 
+    // RRSIの付与設定
+    loraConfigSend("p 1"); 
+    // UART転送速度設定
+    loraConfigSend("r 1"); 
+    // 自動送信間隔
+    loraConfigSend("B 0"); 
+    // 自動送信データ設定
+    loraConfigSend("C receiveSide"); 
+    // 設定を保存する
+    loraConfigSend("w");
+    // 通信の開始
+    loraConfigSend("z");
+    Serial.println("Set up OK!");
+}
+
+void loraConfigSend(String Config){
+    LoraSerial.println(Config);
+    clearBuffer();
+}
+
+void clearBuffer() {
+    delay(CMDDELAY);
+    while (LoraSerial.available() > 0) LoraSerial.read();
+}
+
+void loraDataRead(){
+    String Data;
+    if(LoraSerial.read() == -1){
+        Serial.println("Nothing Data");
+    }else{
+        Data = LoraSerial.readStringUntil('\r\n');//CRおよびLFのため
+        clearBuffer();
+        Serial.println(Data.substring(11)); //データ部分だけ表示
+    }
+    delay(READTIME);
+}
+
+void setup()
+{
+    set_sleep_mode(SLEEP_MODE_PWR_DOWN);  //スリープモード設定
+
+    pinMode(LED, OUTPUT);                   //13を出力設定(LED用)
+    pinMode(inPin, INPUT_PULLUP);           //5番をプルアップ設定
+
+    attachInterrupt(0, interrput, FALLING); // 外部割り込みを開始する。
+                                            // message 割り込み時に実行される関数
+                                            // FALLING ピンの状態が HIGH → LOW になった時に割り込み
+
+    Serial.begin(9600);                     //siralの速度
+    Serial.print("start!!\n---------------------------\n");
+
+    restartLora();
+    loraInit();
+    setRtcConfig();
+}
+
+void loop()
+{
+    int n = 0;
+    sleep_enable();     //スリープを有効化
+    sleep_cpu();        //スリープ開始(ここでプログラムは停止する)
+    sleep_disable();    //スリープを無効化
+    digitalWrite(LED, 1);
+    while (n < 5)
+    {
+        loraDataRead();
+        n++;
+    }
+    
+    n = 0;
+    
+    digitalWrite(LED, 0);
+}

--- a/RTC_Lora_sleep1/RTC_Lora_Receive/RTC_Lora_Receive.ino
+++ b/RTC_Lora_sleep1/RTC_Lora_Receive/RTC_Lora_Receive.ino
@@ -18,6 +18,7 @@
 
 SoftwareSerial LoraSerial(LORA_RX, LORA_TX);
 
+/* Sleepを解除する割り込み関数 */
 void interrput()
 {
     Serial.println("interrupt_message");
@@ -25,6 +26,7 @@ void interrput()
     Serial.println("-----------------");
 }
 
+/* RTCの設定を初期化する関数 */
 void setRtcConfig(){
     Wire.begin(); // arudinoをマスターとして接続
     delay(1000);  // 発振子の動作待機
@@ -59,7 +61,7 @@ void setRtcConfig(){
     Wire.endTransmission();
 }
 
-// LoRaを再起動させる関数
+/* Loraを再起動させる関数 */
 void restartLora(){
     pinMode(RST_PIN, OUTPUT);
     digitalWrite(RST_PIN, LOW);
@@ -71,6 +73,7 @@ void restartLora(){
     LoraSerial.begin(BAUTRATE);
 }
 
+/* loraの初期化関数 */
 void loraInit() {
     Serial.println("Start...");
     // コマンドモード開始
@@ -110,11 +113,13 @@ void loraInit() {
     Serial.println("Set up OK!");
 }
 
+/* loraにConfigを送る関数 */
 void loraConfigSend(String Config){
     LoraSerial.println(Config);
     clearBuffer();
 }
 
+/* bufferを初期化する関数 */
 void clearBuffer() {
     delay(CMDDELAY);
     while (LoraSerial.available() > 0) LoraSerial.read();
@@ -132,11 +137,13 @@ void loraDataRead(){
     delay(READTIME);
 }
 
+/* Arduino,Loraをスリープさせる関数 */
 void setSystemSleep(){
     digitalWrite(SLEEP_PIN, HIGH);          //Lora sleep_mode
     set_sleep_mode(SLEEP_MODE_PWR_DOWN);    //スリープモード設定
 }
 
+/* Main関数 */
 void setup()
 {
     pinMode(SLEEP_PIN,OUTPUT);         //Loraのスリープピン初期化

--- a/RTC_Lora_sleep1/RTC_Lora_Receive/RTC_Lora_Receive.ino
+++ b/RTC_Lora_sleep1/RTC_Lora_Receive/RTC_Lora_Receive.ino
@@ -184,6 +184,3 @@ void loop()
     setSystemSleep();    
     digitalWrite(LED, 0);
 }
-
-
-

--- a/RTC_Lora_sleep1/RTC_Lora_send/RTC_Lora_Send.ino
+++ b/RTC_Lora_sleep1/RTC_Lora_send/RTC_Lora_Send.ino
@@ -17,13 +17,6 @@
 
 SoftwareSerial LoraSerial(LORA_RX, LORA_TX);
 
-/* Sleepを解除する割り込み関数 */
-void interrput()
-{
-    Serial.println("interrupt_message");
-    Serial.println("light up LED 5s");
-}
-
 /* RTCの設定を初期化する関数 */
 void setRtcConfig(){
     Wire.begin(); // arudinoをマスターとして接続
@@ -57,57 +50,6 @@ void setRtcConfig(){
     Wire.write(0x00);       // 00 Control 1　STOP = 0 動作開始
     Wire.write(0b00010001); //Control 2 Ti/Tp = 1 TIE = 1
     Wire.endTransmission();
-}
-
-/* Arduino,Loraをスリープさせる関数 */
-void setSystemSleep(){
-    digitalWrite(SLEEP_PIN, HIGH);          //Lora sleep_mode
-    set_sleep_mode(SLEEP_MODE_PWR_DOWN);    //スリープモード設定
-}
-
-/* Main関数 */
-void setup()
-{
-    pinMode(SLEEP_PIN,OUTPUT);         //Loraのスリープピン初期化
-    digitalWrite(SLEEP_PIN, LOW);      //Low = active_mode　High = sleep_mode
-
-    pinMode(LED, OUTPUT);                   //13を出力設定(LED用)
-    pinMode(INPIN, INPUT_PULLUP);           //2番をプルアップ設定
-    attachInterrupt(0, interrput, FALLING); // 外部割り込みを開始する。
-                                            // message 割り込み時に実行される関数
-                                            // FALLING ピンの状態が HIGH → LOW になった時に割り込み
-    Serial.begin(9600);                     //siralの速度
-    Serial.print("start!!\n---------------------------\n");
-
-    setSystemSleep();
-    restartLora();
-    loraInit();
-    setRtcConfig();
-}
-
-void loop()
-{
-    sleep_enable();     //スリープを有効化
-    sleep_cpu();        //スリープ開始(ここでプログラムは停止する)
-    sleep_disable();    //スリープを無効化
-
-    digitalWrite(SLEEP_PIN, LOW);         //Lora Acctive_mode
-    digitalWrite(LED, 1);
-    loraDataSend();                     //loraDatasend
-    setSystemSleep();                   //System Sleep_mode
-    digitalWrite(LED, 0);
-}
-
-/* Loraを再起動させる関数 */
-void restartLora(){
-    pinMode(RST_PIN, OUTPUT);
-    digitalWrite(RST_PIN, LOW);
-    delay(BOOTDELAY);
-    digitalWrite(RST_PIN, HIGH); 
-    delay(BOOTDELAY);
-
-    Serial.begin(BAUTRATE);
-    LoraSerial.begin(BAUTRATE);
 }
 
 /* loraの初期化関数 */
@@ -159,6 +101,31 @@ void clearBuffer() {
     while (LoraSerial.available() > 0) LoraSerial.read();
 }
 
+/* Loraを再起動させる関数 */
+void restartLora(){
+    pinMode(RST_PIN, OUTPUT);
+    digitalWrite(RST_PIN, LOW);
+    delay(BOOTDELAY);
+    digitalWrite(RST_PIN, HIGH); 
+    delay(BOOTDELAY);
+
+    Serial.begin(BAUTRATE);
+    LoraSerial.begin(BAUTRATE);
+}
+
+/* Arduino,Loraをスリープさせる関数 */
+void setSystemSleep(){
+    digitalWrite(SLEEP_PIN, HIGH);          //Lora sleep_mode
+    set_sleep_mode(SLEEP_MODE_PWR_DOWN);    //スリープモード設定
+}
+
+/* Sleepを解除する割り込み関数 */
+void interrput()
+{
+    Serial.println("interrupt_message");
+    Serial.println("light up LED 5s");
+}
+
 /* LoraからDataを送る関数 */
 void loraDataSend(){
     delay(1000);
@@ -171,4 +138,37 @@ void loraDataSend(){
     LoraSerial.println("hooooooooooooooooooooooooogedesuwaaaaaa");
     delay(1000);
     LoraSerial.println("hooooooooooooooooooooooooogedesuwaaaaaa");
+}
+
+/* Main関数 */
+void setup()
+{
+    pinMode(SLEEP_PIN,OUTPUT);         //Loraのスリープピン初期化
+    digitalWrite(SLEEP_PIN, LOW);      //Low = active_mode　High = sleep_mode
+
+    pinMode(LED, OUTPUT);                   //13を出力設定(LED用)
+    pinMode(INPIN, INPUT_PULLUP);           //2番をプルアップ設定
+    attachInterrupt(0, interrput, FALLING); // 外部割り込みを開始する。
+                                            // message 割り込み時に実行される関数
+                                            // FALLING ピンの状態が HIGH → LOW になった時に割り込み
+    Serial.begin(9600);                     //siralの速度
+    Serial.print("start!!\n---------------------------\n");
+
+    setSystemSleep();
+    restartLora();
+    loraInit();
+    setRtcConfig();
+}
+
+void loop()
+{
+    sleep_enable();     //スリープを有効化
+    sleep_cpu();        //スリープ開始(ここでプログラムは停止する)
+    sleep_disable();    //スリープを無効化
+
+    digitalWrite(SLEEP_PIN, LOW);         //Lora Acctive_mode
+    digitalWrite(LED, 1);
+    loraDataSend();                     //loraDatasend
+    setSystemSleep();                   //System Sleep_mode
+    digitalWrite(LED, 0);
 }

--- a/RTC_Lora_sleep1/RTC_Lora_send/RTC_Lora_Send.ino
+++ b/RTC_Lora_sleep1/RTC_Lora_send/RTC_Lora_Send.ino
@@ -7,22 +7,24 @@
 #define RTCaddress 0xa2 >> 1
 //RTC8564のスレーブアドレスは『0xA2』固定だが、Wireライブラリでは7ビットでデバイス特定をするため、右に1ビットシフトさせて指定
 
-#define SLEEP_PIN 12   /*スリープピン*/
-#define RST_PIN 13      /*リセットピン*/
-#define LORA_RX 4       /*Software_RX_4*/
-#define LORA_TX 5       /*Software_TX_5*/
-#define CMDDELAY 100    /*CMD待機時間*/
-#define BOOTDELAY 1500  /*Boot待機時間*/
-#define BAUTRATE 9600   /*BautRate*/
+#define SLEEP_PIN 12   /* スリープピン */
+#define RST_PIN 13      /* リセットピン */
+#define LORA_RX 4       /* Software_RX_4 */
+#define LORA_TX 5       /* Software_TX_5 */
+#define CMDDELAY 100    /* CMD待機時間 */
+#define BOOTDELAY 1500  /* Boot待機時間 */
+#define BAUTRATE 9600   /* BautRate */
 
 SoftwareSerial LoraSerial(LORA_RX, LORA_TX);
 
+/* Sleepを解除する割り込み関数 */
 void interrput()
 {
     Serial.println("interrupt_message");
     Serial.println("light up LED 5s");
 }
 
+/* RTCの設定を初期化する関数 */
 void setRtcConfig(){
     Wire.begin(); // arudinoをマスターとして接続
     delay(1000);  // 発振子の動作待機
@@ -57,11 +59,13 @@ void setRtcConfig(){
     Wire.endTransmission();
 }
 
+/* Arduino,Loraをスリープさせる関数 */
 void setSystemSleep(){
     digitalWrite(SLEEP_PIN, HIGH);          //Lora sleep_mode
     set_sleep_mode(SLEEP_MODE_PWR_DOWN);    //スリープモード設定
 }
 
+/* Main関数 */
 void setup()
 {
     pinMode(SLEEP_PIN,OUTPUT);         //Loraのスリープピン初期化
@@ -94,7 +98,7 @@ void loop()
     digitalWrite(LED, 0);
 }
 
-// LoRaを再起動させる関数
+/* Loraを再起動させる関数 */
 void restartLora(){
     pinMode(RST_PIN, OUTPUT);
     digitalWrite(RST_PIN, LOW);
@@ -106,6 +110,7 @@ void restartLora(){
     LoraSerial.begin(BAUTRATE);
 }
 
+/* loraの初期化関数 */
 void loraInit() {
     Serial.println("Start...");
     // コマンドモード開始
@@ -142,17 +147,19 @@ void loraInit() {
     Serial.println("Set up OK!");
 }
 
+/* loraにConfigを送る関数 */
 void loraConfigSend(String Config){
     LoraSerial.println(Config);
     clearBuffer();
 }
 
+/* bufferを初期化する関数 */
 void clearBuffer() {
     delay(CMDDELAY);
     while (LoraSerial.available() > 0) LoraSerial.read();
 }
 
-//dataを送信する関数
+/* LoraからDataを送る関数 */
 void loraDataSend(){
     delay(1000);
     LoraSerial.println("hooooooooooooooooooooooooogedesuwaaaaaa");

--- a/RTC_Lora_sleep1/RTC_Lora_send/RTC_Lora_Send.ino
+++ b/RTC_Lora_sleep1/RTC_Lora_send/RTC_Lora_Send.ino
@@ -56,41 +56,41 @@ void setRtcConfig(){
 void setLoraInit() {
     Serial.println("Start...");
     // コマンドモード開始
-    loraConfigSend("2"); 
+    setLoraConfig("2"); 
     //nodeの種別設定
-    loraConfigSend("node 2");
+    setLoraConfig("node 2");
     // bw（帯域幅の設定）
-    loraConfigSend("bw 5"); 
+    setLoraConfig("bw 5"); 
     // sf（拡散率の設定）
-    loraConfigSend("sf 12"); 
+    setLoraConfig("sf 12"); 
     //channel設定
-    loraConfigSend("channel 1"); 
+    setLoraConfig("channel 1"); 
     // 自分が参加するPANネットワークアドレスの設定
-    loraConfigSend("panid 0002"); 
+    setLoraConfig("panid 0002"); 
     // 自分のノードIDを設定
-    loraConfigSend("ownid 0012"); 
+    setLoraConfig("ownid 0012"); 
     //送信元ノードネットワークアドレス
-    loraConfigSend("dstid 1012"); 
+    setLoraConfig("dstid 1012"); 
     // ack受信の設定
-    loraConfigSend("ack 2"); 
+    setLoraConfig("ack 2"); 
     // 転送モード設定
-    loraConfigSend("n 1"); 
+    setLoraConfig("n 1"); 
     // RRSIの付与設定
-    loraConfigSend("p 1"); 
+    setLoraConfig("p 1"); 
     // sleepの設定
-    loraConfigSend("s 3"); 
+    setLoraConfig("s 3"); 
     // UART転送速度設定
-    loraConfigSend("r 1"); 
+    setLoraConfig("r 1"); 
     // 設定を保存する
-    loraConfigSend("w");
+    setLoraConfig("w");
     // 通信の開始
-    loraConfigSend("z");
+    setLoraConfig("z");
     // 送信データの内容
     Serial.println("Set up OK!");
 }
 
 /* loraにConfigを送る関数 */
-void loraConfigSend(String Config){
+void setLoraConfig(String Config){
     LoraSerial.println(Config);
     clearBuffer();
 }

--- a/RTC_Lora_sleep1/RTC_Lora_send/RTC_Lora_Send.ino
+++ b/RTC_Lora_sleep1/RTC_Lora_send/RTC_Lora_Send.ino
@@ -1,0 +1,155 @@
+#include <Wire.h>
+#include <avr/sleep.h>
+#include <SoftwareSerial.h>
+
+#define inPin 2
+#define LED 10
+#define RTCaddress 0xa2 >> 1
+//RTC8564のスレーブアドレスは『0xA2』固定だが、Wireライブラリでは7ビットでデバイス特定をするため、右に1ビットシフトさせて指定
+
+#define RST_PIN 13      /*リセットピン*/
+#define LORA_RX 4       /*Software_RX_4*/
+#define LORA_TX 5       /*Software_TX_5*/
+#define CMDDELAY 100    /*CMD待機時間*/
+#define BOOTDELAY 1500  /*Boot待機時間*/
+#define BAUTRATE 9600   /*BautRate*/
+
+SoftwareSerial LoraSerial(LORA_RX, LORA_TX);
+
+void interrput()
+{
+    Serial.println("interrupt_message");
+    Serial.println("light up LED 5s");
+}
+
+void setRtcConfig(){
+    Wire.begin(); // arudinoをマスターとして接続
+    delay(1000);  // 発振子の動作待機
+
+    Wire.beginTransmission(RTCaddress); //接続するIC2のモジュールを選択
+    Wire.write(0x00);                   // データを転送するレジスタ番号を指定
+    Wire.write(0b00100000);                   // 00 Control 1　STOP = 1 動作停止
+    Wire.write(0x00);                         // 01 Control 2 
+    Wire.write(0b00000001);                   // 02 Seconds　
+    Wire.write(0b00000000);                   // 03 Minutes
+    Wire.write(0b00000000);                   // 04 Hours
+    Wire.write(0b00000001);                   // 05 Days
+    Wire.write(0b00000001);                   // 06 Weekdays
+    Wire.write(0b00000001);                   // 07 Months
+    Wire.write(0b00100000);                   // 08 Years
+    //20年1月１日00:00に設定
+
+    //Alram レジスタ
+    Wire.write(0x00);       // 09 Minutes Alarm　
+    Wire.write(0x00);       // 0A Hours Alarm
+    Wire.write(0x00);       // 0B Days Alarm
+    Wire.write(0x00);       // 0C Weekdays Alarm
+
+    //timerレジスタ
+    Wire.write(0x00);       // 0D CLKOUT
+    Wire.write(0b10000010); // 0E TimerControl
+    Wire.write(0b00001111); // 0F Timer 15秒設定
+
+    // Control 設定
+    Wire.write(0x00);       // 00 Control 1　STOP = 0 動作開始
+    Wire.write(0b00010001); //Control 2 Ti/Tp = 1 TIE = 1
+    Wire.endTransmission();
+}
+
+void setup()
+{
+    set_sleep_mode(SLEEP_MODE_PWR_DOWN);  //スリープモード設定
+
+    pinMode(LED, OUTPUT);                   //13を出力設定(LED用)
+    pinMode(inPin, INPUT_PULLUP);           //2番をプルアップ設定
+    attachInterrupt(0, interrput, FALLING); // 外部割り込みを開始する。
+                                            // message 割り込み時に実行される関数
+                                            // FALLING ピンの状態が HIGH → LOW になった時に割り込み
+    Serial.begin(9600);                     //siralの速度
+    Serial.print("start!!\n---------------------------\n");
+    restartLora();
+    loraInit();
+    setRtcConfig();
+}
+
+void loop()
+{
+    sleep_enable();     //スリープを有効化
+    sleep_cpu();        //スリープ開始(ここでプログラムは停止する)
+    sleep_disable();    //スリープを無効化
+    digitalWrite(LED, 1);
+
+    loraDataSend();
+
+    digitalWrite(LED, 0);
+}
+
+// LoRaを再起動させる関数
+void restartLora(){
+    pinMode(RST_PIN, OUTPUT);
+    digitalWrite(RST_PIN, LOW);
+    delay(BOOTDELAY);
+    digitalWrite(RST_PIN, HIGH); 
+    delay(BOOTDELAY);
+
+    Serial.begin(BAUTRATE);
+    LoraSerial.begin(BAUTRATE);
+}
+
+void loraInit() {
+    Serial.println("Start...");
+    // コマンドモード開始
+    loraConfigSend("2"); 
+    //nodeの種別設定
+    loraConfigSend("node 2");
+    // bw（帯域幅の設定）
+    loraConfigSend("bw 5"); 
+    // sf（拡散率の設定）
+    loraConfigSend("sf 12"); 
+    //channel設定
+    loraConfigSend("channel 1"); 
+    // 自分が参加するPANネットワークアドレスの設定
+    loraConfigSend("panid 0002"); 
+    // 自分のノードIDを設定
+    loraConfigSend("ownid 0012"); 
+    //送信元ノードネットワークアドレス
+    loraConfigSend("dstid 1012"); 
+    // ack受信の設定
+    loraConfigSend("ack 2"); 
+    // 転送モード設定
+    loraConfigSend("n 1"); 
+    // RRSIの付与設定
+    loraConfigSend("p 1"); 
+    // UART転送速度設定
+    loraConfigSend("r 1"); 
+    // 設定を保存する
+    loraConfigSend("w");
+    // 通信の開始
+    loraConfigSend("z");
+    // 送信データの内容
+    Serial.println("Set up OK!");
+}
+
+void loraConfigSend(String Config){
+    LoraSerial.println(Config);
+    clearBuffer();
+}
+
+void clearBuffer() {
+    delay(CMDDELAY);
+    while (LoraSerial.available() > 0) LoraSerial.read();
+}
+
+//dataを送信する関数
+void loraDataSend(){
+    delay(1000);
+    LoraSerial.println("hooooooooooooooooooooooooogedesuwaaaaaa");
+    delay(1000);
+    LoraSerial.println("hooooooooooooooooooooooooogedesuwaaaaaa");
+    delay(1000);
+    LoraSerial.println("hooooooooooooooooooooooooogedesuwaaaaaa");
+    delay(1000);
+    LoraSerial.println("hooooooooooooooooooooooooogedesuwaaaaaa");
+    delay(1000);
+    LoraSerial.println("hooooooooooooooooooooooooogedesuwaaaaaa");
+}

--- a/RTC_Lora_sleep1/RTC_Lora_send/RTC_Lora_Send.ino
+++ b/RTC_Lora_sleep1/RTC_Lora_send/RTC_Lora_Send.ino
@@ -87,7 +87,7 @@ void loop()
     sleep_cpu();        //スリープ開始(ここでプログラムは停止する)
     sleep_disable();    //スリープを無効化
 
-    digitalWrite(ES920LR_RST_PIN, LOW); //Lora Acctive_mode
+    digitalWrite(SLEEP_PIN, LOW);         //Lora Acctive_mode
     digitalWrite(LED, 1);
     loraDataSend();                     //loraDatasend
     setSystemSleep();                   //System Sleep_mode

--- a/RTC_Lora_sleep1/RTC_Lora_send/RTC_Lora_Send.ino
+++ b/RTC_Lora_sleep1/RTC_Lora_send/RTC_Lora_Send.ino
@@ -53,7 +53,7 @@ void setRtcConfig(){
 }
 
 /* loraの初期化関数 */
-void loraInit() {
+void setLoraInit() {
     Serial.println("Start...");
     // コマンドモード開始
     loraConfigSend("2"); 
@@ -102,7 +102,7 @@ void clearBuffer() {
 }
 
 /* Loraを再起動させる関数 */
-void restartLora(){
+void setRestartLora(){
     pinMode(RST_PIN, OUTPUT);
     digitalWrite(RST_PIN, LOW);
     delay(BOOTDELAY);
@@ -127,7 +127,7 @@ void interrput()
 }
 
 /* LoraからDataを送る関数 */
-void loraDataSend(){
+void sendLoraData(){
     delay(1000);
     LoraSerial.println("TestData_1");
     delay(1000);
@@ -155,8 +155,8 @@ void setup()
     Serial.print("start!!\n---------------------------\n");
 
     setSystemSleep();
-    restartLora();
-    loraInit();
+    setRestartLora();
+    setLoraInit();
     setRtcConfig();
 }
 
@@ -168,7 +168,7 @@ void loop()
 
     digitalWrite(SLEEP_PIN, LOW);         //Lora Acctive_mode
     digitalWrite(LED, 1);
-    loraDataSend();                     //loraDatasend
+    sendLoraData();                     //loraDatasend
     setSystemSleep();                   //System Sleep_mode
     digitalWrite(LED, 0);
 }

--- a/RTC_Lora_sleep1/RTC_Lora_send/RTC_Lora_Send.ino
+++ b/RTC_Lora_sleep1/RTC_Lora_send/RTC_Lora_Send.ino
@@ -129,15 +129,15 @@ void interrput()
 /* LoraからDataを送る関数 */
 void loraDataSend(){
     delay(1000);
-    LoraSerial.println("hooooooooooooooooooooooooogedesuwaaaaaa");
+    LoraSerial.println("TestData_1");
     delay(1000);
-    LoraSerial.println("hooooooooooooooooooooooooogedesuwaaaaaa");
+    LoraSerial.println("TestData_2");
     delay(1000);
-    LoraSerial.println("hooooooooooooooooooooooooogedesuwaaaaaa");
+    LoraSerial.println("TestData_3");
     delay(1000);
-    LoraSerial.println("hooooooooooooooooooooooooogedesuwaaaaaa");
+    LoraSerial.println("TestData_4");
     delay(1000);
-    LoraSerial.println("hooooooooooooooooooooooooogedesuwaaaaaa");
+    LoraSerial.println("TestData_5");
 }
 
 /* Main関数 */

--- a/RTC_Lora_sleep1/RTC_Lora_send/RTC_Lora_Send.ino
+++ b/RTC_Lora_sleep1/RTC_Lora_send/RTC_Lora_Send.ino
@@ -64,8 +64,8 @@ void setSystemSleep(){
 
 void setup()
 {
-    pinMode(Lora_SLEEP_PIN,OUTPUT);         //Loraのスリープピン初期化
-    digitalWrite(Lora_SLEEP_PIN, LOW);      //Low = active_mode　High = sleep_mode
+    pinMode(SLEEP_PIN,OUTPUT);         //Loraのスリープピン初期化
+    digitalWrite(SLEEP_PIN, LOW);      //Low = active_mode　High = sleep_mode
 
     pinMode(LED, OUTPUT);                   //13を出力設定(LED用)
     pinMode(INPIN, INPUT_PULLUP);           //2番をプルアップ設定


### PR DESCRIPTION
close #17 

## 配線方法
![image](https://user-images.githubusercontent.com/58362633/99500702-105d3100-29be-11eb-9d5e-fa521cddfc68.png)

![image](https://user-images.githubusercontent.com/58362633/100498491-e669f280-31a5-11eb-98a1-fbdf65fbc549.png)
これと、評価ボードのピンアサインが対応してる

## memo
送受信両方
arduino | Lora
-- | --
GND | GND
5V | 2
5V | 13
D12 |  16 (SW_INT)
D4 | 8
D5 | 9
D13 | 24

arduino |  RTC
-- | --
GND | 4(VSS)
5V | 8(VDD)
SCL |  6(SCL)
SDA | 5(SDA)
D12 |  16 (SW_INT)
D2 | 3(INT)


## 送信側
設定内容 | シリアル通信
-- | --
ノード種別設定 | Coordinator
帯域幅 | 250
拡散率設定 | 12
無線チャンネル設定 | 1
PAN   ネットワークアドレス設定 | 0002
自ノードネットワークアドレス設定 | 0012
送信先ノードネットワークアドレス設定 | 1012
Acknowledge   使用設定 | OFF
受信電波強度(RSSI)付与設定  | ON
動作モード設定 | Config
UART   転送速度 | 9600
自動送信間隔設定 | 5
自動送信データ設定 | 1234567890(10個)

## 受信側
設定内容 | シリアル通信
-- | --
ノード種別設定 | EndDevice
帯域幅 | 250
拡散率設定 | 12
無線チャンネル設定 | 1
PAN   ネットワークアドレス設定 | 0002
自ノードネットワークアドレス設定 | 1012
送信先ノードネットワークアドレス設定 | 0012
Acknowledge   使用設定 | OFF
受信電波強度(RSSI)付与設定  | ON
動作モード設定 | Config
UART   転送速度 | 9600

※BautRateが115200の場合文字化けするので注意が必要
9600ならバグらない